### PR TITLE
Fix: Did not detect (all kinds of) connection loss

### DIFF
--- a/aids.c
+++ b/aids.c
@@ -151,7 +151,7 @@ static int ID_connect(void) {
 
 	sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0) {
-		fprintf(stderr, "ID_connect() socket failed %d\n", errno);
+		fprintf(stderr, "ID_connect() socket failed: %s\r\n", strerror(errno));
 		return -1;
 	}
 
@@ -160,20 +160,20 @@ static int ID_connect(void) {
 	tv.tv_usec = 0;
 	c = setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
 	if (c < 0) {
-		fprintf(stderr, "ID_connect() setsockopt failed %d\n", errno);
+		fprintf(stderr, "ID_connect() setsockopt failed: %s\r\n", strerror(errno));
 		return -1;
 	}
 
 	err = getaddrinfo(ID_SERVER, ID_SERVER_PORT, NULL, &a);
 	if (err) {
-		fprintf(stderr, "ID_connect() getaddrinfo failed %d\n", err);
+		fprintf(stderr, "ID_connect() getaddrinfo failed: %s\r\n", strerror(err));
 		return -1;
 	}
 
 	c = connect(sock, a->ai_addr, a->ai_addrlen);
 	freeaddrinfo(a);
 	if (c < 0) {
-		fprintf(stderr, "ID_connect() connect failed %d\n", errno);
+		fprintf(stderr, "ID_connect() connect failed: %s\r\n", strerror(errno));
 		return -1;
 	}
 
@@ -218,6 +218,7 @@ static void* ID_collect(void* nyx) {
 			if (x < 0) {
 				// timeout ... check if still connected
 				// and/or maybe reconnect
+				fprintf(stderr, "ID_collect() recv failed, closing socket: %s\r\n", strerror(errno));
 				close(sock); // lazy...
 				connected = 0;
 				break;
@@ -294,13 +295,13 @@ void deliver_id() {
 
 	sock = socket(AF_INET, SOCK_STREAM, 0);
 	if (sock < 0) {
-		fprintf(stderr, "deliver_id() socket failed %d\n", errno);
+		fprintf(stderr, "deliver_id() socket failed: %s\r\n", strerror(errno));
 		return;
 	}
 
 	c = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof(int));
 	if (c < 0) {
-		fprintf(stderr, "deliver_id() setsockopt failed %d\n", errno);
+		fprintf(stderr, "deliver_id() setsockopt failed: %s\r\n", strerror(errno));
 		return;
 	}
 
@@ -310,13 +311,13 @@ void deliver_id() {
 	c = bind(sock, (struct sockaddr*)&serv, sizeof(serv));
 	if (c < 0) {
 		close(sock);
-		fprintf(stderr, "deliver_id() bind failed %d\n", errno);
+		fprintf(stderr, "deliver_id() bind failed: %s\r\n", strerror(errno));
 		return;
 	}
 
 	c = listen(sock, 1);
 	if (c < 0) {
-		fprintf(stderr, "deliver_id() listen failed %d\n", errno);
+		fprintf(stderr, "deliver_id() listen failed: %s\r\n", strerror(errno));
 		return;
 	}
 
@@ -326,7 +327,7 @@ void deliver_id() {
 		sin_size = sizeof(client_addr);
 		con = accept(sock, (struct sockaddr*)&client_addr, &sin_size);
 		if (con < 0) {
-			fprintf(stderr, "deliver_id() accept failed %d\n", errno);
+			fprintf(stderr, "deliver_id() accept failed: %s\r\n", strerror(errno));
 			break;
 		}
 
@@ -344,7 +345,7 @@ void deliver_id() {
 			if (c < 0) {
 				close(con);
 				if (errno != ECONNRESET && errno != EPIPE) {
-					fprintf(stderr, "deliver_id() send failed %d\n", errno);
+					fprintf(stderr, "deliver_id() send failed: %s\r\n", strerror(errno));
 					break;
 				}
 			}

--- a/aids.c
+++ b/aids.c
@@ -177,6 +177,8 @@ static int ID_connect(void) {
 		return -1;
 	}
 
+
+	fprintf(stdout, "Connect successful...\r\n");
 	return sock;
 }
 
@@ -206,6 +208,7 @@ static void* ID_collect(void* nyx) {
 #endif
 				exit(0);
 			}
+			fprintf(stderr, "Connect failed, %d/20 retries left...\r\n", recon_retry);
 			sleep(1);
 			continue;
 		}
@@ -225,6 +228,7 @@ static void* ID_collect(void* nyx) {
 			} else if (x == ID_MESSAGE_SIZE) {
 				// we dont want these big messages, just drop it
 				// and wait for the next one
+				printf("ID_collect() skipping invalid message\r\n");
 				continue;
 			}
 			// decode message and put into events array
@@ -235,7 +239,7 @@ static void* ID_collect(void* nyx) {
 
 			if (x <= 0) {
 				// error reading packet, just ignore it
-				DEBUG(printf("ID_collect() skipping unparsable message\r\n"));
+				printf("ID_collect() skipping unparsable message\r\n");
 				continue;
 			}
 

--- a/aids.c
+++ b/aids.c
@@ -336,7 +336,7 @@ void deliver_id() {
 		}
 
 #ifdef WIN32
-		getnameinfo((const sockaddr*)&client_addr, sizeof(client_addr), s, INET_ADDRSTRLEN, NULL, 0, 0);
+		getnameinfo((const struct sockaddr *)&client_addr, sizeof(client_addr), s, INET_ADDRSTRLEN, NULL, 0, 0);
 #else
 		inet_ntop(AF_INET, (const void*)(&client_addr.sin_addr), s, INET_ADDRSTRLEN);
 #endif

--- a/aids.c
+++ b/aids.c
@@ -209,7 +209,7 @@ static void* ID_collect(void* nyx) {
 				exit(0);
 			}
 			fprintf(stderr, "Connect failed, %d/20 retries left...\r\n", recon_retry);
-			sleep(1);
+			sleep(2*recon_retry);
 			continue;
 		}
 

--- a/aids.c
+++ b/aids.c
@@ -218,7 +218,7 @@ static void* ID_collect(void* nyx) {
 			x = recv(sock, buff, ID_MESSAGE_SIZE, 0);
 			gettimeofday(&tv, NULL);
 		
-			if (x < 0) {
+			if (x <= 0) {
 				// timeout ... check if still connected
 				// and/or maybe reconnect
 				fprintf(stderr, "ID_collect() recv failed, closing socket: %s\r\n", strerror(errno));

--- a/aids.c
+++ b/aids.c
@@ -46,8 +46,8 @@
 #define ID_EVENT_WINDOW_SIZE	40
 
 // Turns on mostly receive and decode debug messages
-#define DEBUG(x) x
-//#define DEBUG(x)
+//#define DEBUG(x) x
+#define DEBUG(x)
 
 // elements of circular buffer with received EventID mesg
 typedef struct {

--- a/aids.c
+++ b/aids.c
@@ -177,8 +177,7 @@ static int ID_connect(void) {
 		return -1;
 	}
 
-
-	fprintf(stdout, "Connect successful...\r\n");
+	fprintf(stdout, "Connection to %s successful\r\n", a->ai_canonname ?: ID_SERVER);
 	return sock;
 }
 
@@ -209,6 +208,7 @@ static void* ID_collect(void* nyx) {
 				exit(0);
 			}
 			fprintf(stderr, "Connect failed, %d/20 retries left...\r\n", recon_retry);
+			fprintf(stderr, "Next retry in %dsec\r\n", 2*recon_retry);
 			sleep(2*recon_retry);
 			continue;
 		}
@@ -221,7 +221,8 @@ static void* ID_collect(void* nyx) {
 			if (x <= 0) {
 				// timeout ... check if still connected
 				// and/or maybe reconnect
-				fprintf(stderr, "ID_collect() recv failed, closing socket: %s\r\n", strerror(errno));
+				fprintf(stderr, "ID_collect() recv failed, %d bytes received, closing socket: %s\r\n",
+					x, strerror(errno));
 				close(sock); // lazy...
 				connected = 0;
 				break;

--- a/aids.c
+++ b/aids.c
@@ -200,7 +200,7 @@ static void* ID_collect(void* nyx) {
 			// Maybe try to reconnect etc pp
 			recon_retry++;
 			if (recon_retry > 20) {
-				fprintf(stderr, "ID_collect() giving up to reconnect\n", errno);
+				fprintf(stderr, "ID_collect() giving up to reconnect\r\n");
 #ifdef WIN32
 				WSACleanup();
 #endif
@@ -234,7 +234,7 @@ static void* ID_collect(void* nyx) {
 
 			if (x <= 0) {
 				// error reading packet, just ignore it
-				DEBUG(printf("skipping unparsable message\n"));
+				DEBUG(printf("ID_collect() skipping unparsable message\r\n"));
 				continue;
 			}
 
@@ -246,7 +246,7 @@ static void* ID_collect(void* nyx) {
 				+ 1000000 * (unsigned long long int) tv.tv_sec
 				- 100000 * (unsigned long long int) id;
 
-			DEBUG(printf("ID %2d found %lx -=> Offset %lld\n", events_idx, id, offset));
+			DEBUG(printf("ID %2d found %lx -=> Offset %lld\r\n", events_idx, id, offset));
 
 			// fill all buffer entries with the first ID we receive
 			// this alleviates us of several nasty sanity checks ;)
@@ -258,7 +258,7 @@ static void* ID_collect(void* nyx) {
 					events[events_idx].id = id;
 					events[events_idx].offset = offset;
 				}
-				printf("Connected to EventID server and getting data\n");
+				printf("Connected to EventID server and getting data\r\n");
 
 			}
 			events[events_idx].t.tv_sec = tv.tv_sec;
@@ -320,7 +320,7 @@ void deliver_id() {
 		return;
 	}
 
-	printf("waiting for connections...\n");
+	printf("waiting for connections...\r\n");
 
 	for (;;) { // main accept() loop
 		sin_size = sizeof(client_addr);
@@ -335,7 +335,7 @@ void deliver_id() {
 #else
 		inet_ntop(AF_INET, (const void*)(&client_addr.sin_addr), s, INET_ADDRSTRLEN);
 #endif
-		printf("Connected to %s\n", s);
+		printf("Connected to %s\r\n", s);
 
 		do { // loop for repeated shouts within one connect
 			calc_id(&myid);
@@ -356,7 +356,7 @@ void deliver_id() {
 			while (c>0) c = recv(con, msg, sizeof(msg), MSG_DONTWAIT); // flush input queue
 		} while (errno == EAGAIN || errno == EWOULDBLOCK);
 #endif
-		printf("Connection dropped\n");
+		printf("Connection dropped\r\n");
 	}
 	// only reached if failure to open listening socket (= fatal)
 }


### PR DESCRIPTION
On closing the remote server we do not really detect a connection loss, but just get a timed out resv().